### PR TITLE
Make news post created dates manageable (#11)

### DIFF
--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -107,6 +107,19 @@
                   "Position": "4"
                 }
               }
+            },
+            {
+              "PartName": "CommonPart",
+              "Name": "CommonPart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "3"
+                },
+                "CommonPartSettings": {
+                  "DisplayDateEditor": true
+                },
+                "ContentIndexSettings": {}
+              }
             }
           ]
         },
@@ -331,7 +344,7 @@
       "Queries": [
         {
           "Index": "News",
-          "Template": "{\r\n  \"query\": {\r\n    \"bool\": { \r\n      \"must\": [\r\n        { \"terms\": { \"Content.ContentItem.ContentType\": [ \"NewsPost\"] } }\r\n      ]\r\n    }\r\n  },\r\n  \"sort\": {\r\n    \"Content.ContentItem.PublishedUtc\": {\r\n      \"order\": \"desc\"\r\n    }\r\n  },\r\n  \"from\": {{from}},\r\n  \"size\": {{size}}\r\n}",
+          "Template": "{\r\n  \"query\": {\r\n    \"bool\": { \r\n      \"must\": [\r\n        { \"terms\": { \"Content.ContentItem.ContentType\": [ \"NewsPost\"] } }\r\n      ]\r\n    }\r\n  },\r\n  \"sort\": {\r\n    \"Content.ContentItem.CreatedUtc\": {\r\n      \"order\": \"desc\"\r\n    }\r\n  },\r\n  \"from\": {{from}},\r\n  \"size\": {{size}}\r\n}",
           "ReturnContentItems": true,
           "Name": "News",
           "Source": "Lucene",

--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -86,8 +86,7 @@
                   "Pattern": "news/{{ ContentItem | display_text | slugify }}",
                   "AllowUpdatePath": true
                 },
-                "ContentIndexSettings": {},
-                "LinkableContentTypes": []
+                "ContentIndexSettings": {}
               }
             },
             {
@@ -156,7 +155,6 @@
                 "ContentTypePartSettings": {
                   "Position": "1"
                 },
-                "LinkableContentTypes": [],
                 "AutoroutePartSettings": {
                   "AllowCustomPath": true,
                   "Pattern": "{{ ContentItem | display_text | slugify }}",


### PR DESCRIPTION
Note when testing this that the query gets overwritten by the theme boilerplate's queries recipe, will create separate issue for that on that repo.