### PR TITLE
Update thumbnail defaults

### DIFF
--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -201,7 +201,7 @@
                 },
                 "MediaFieldSettings": {
                   "AllowMediaText ": true,
-                  "Hint": "Ideally image should be 350x200.",
+                  "Hint": "Image should be at least 1280x720. While it is often displayed at a much smaller size, in some scenarios thumbnails are displayed in a large format.",
                   "Multiple": false
                 },
                 "ContentIndexSettings": {}
@@ -282,4 +282,3 @@
     }
   ]
 }
-

--- a/Views/Content-NewsPost.Summary.liquid
+++ b/Views/Content-NewsPost.Summary.liquid
@@ -3,24 +3,24 @@
 
 {% assign altText = Model.ContentItem.Content.NewsPost.ThumbnailAlt.Text | default: Model.ContentItem.Content.NewsPost.Thumbnail.MediaTexts[0] %}
 
-<a href="{{ Model.ContentItem | display_url }}" class="card card--news card--equal-height">
+{% assign cssClasses = "card card--news card--equal-height" %}
+
+{% if thumbnailPath != null %}
+    {% assign cssClasses = cssClasses | append: "card--has-media" %}
+{% endif %}
+
+<a href="{{ Model.ContentItem | display_url }}" class="{{ cssClasses }}">
     {% if thumbnailPath != null %}
-    <picture class="card__media">
-        <img class="card__media-image" src="{{ thumbnailPath | asset_url | resize_url: width:350, height:200, mode:'crop' }}" alt="{{ altText }}" />
-    </picture>
-    {% else %}
-    <div class="card__media card__media--empty" style="height: 200px; background-color: #ccc;"></div>
+        <div class="card__media">
+            <img class="card__media-image" src="{{ thumbnailPath | asset_url | resize_url: width:1280, height:720, mode:'crop' }}" alt="{{ altText }}" loading="lazy" />
+        </div>
     {% endif %}
 
     <div class="card__body">
         <header class="card__header">
             <h3 class="card__title">{{ Model.ContentItem | display_text }}</h3>
             <span class="card__meta">
-                {% if isPublished %}
-                    {{ Model.ContentItem.CreatedUtc | local | date: "%d/%m/%Y" }}
-                {% else %}
-                    {{ "Draft" | t }}
-                {% endif %}
+                {{ Model.ContentItem.CreatedUtc | local | date: "%d/%m/%Y" }}
             </span>
         </header>
     </div>


### PR DESCRIPTION
So we don't recommend/enforce a small size for something which usually ends up being displayed very large. 

Also standardised behaviour a bit with how the Card widget works in terms of markup. 

I've also removed the bit that makes it say Draft as that seems to not be useful? But that could go back in if we want to keep it.